### PR TITLE
Remove ReLU activation in PrimaryCaps.

### DIFF
--- a/caps_layers.py
+++ b/caps_layers.py
@@ -24,13 +24,12 @@ class PrimaryCaps(nn.Module):
     PrimaryCaps layers.
     """
     def __init__(self, in_channels, out_capsules, out_capsule_dim,
-                 kernel_size=9, stride=2, is_relu=False):
+                 kernel_size=9, stride=2):
         super(PrimaryCaps, self).__init__()
 
         self.in_channels = in_channels
         self.out_capsules = out_capsules
         self.out_capsule_dim = out_capsule_dim
-        self.is_relu = is_relu
 
         self.capsules = nn.Conv2d(
                 in_channels=in_channels,
@@ -49,8 +48,6 @@ class PrimaryCaps(nn.Module):
         batch_size = x.size(0)
 
         out = self.capsules(x)
-        if self.is_relu:    # ReLU activation
-            out = F.relu(out)
         # out: [batch_size, out_capsules=32 * out_capsule_dim=8 = 256, 6, 6]
 
         _, C, H, W = out.size()

--- a/capsule_network.py
+++ b/capsule_network.py
@@ -16,7 +16,7 @@ from decoder import Decoder
 
 
 class CapsuleNetwork(nn.Module):
-    def __init__(self, routing_iters, is_relu=False):
+    def __init__(self, routing_iters):
         super(CapsuleNetwork, self).__init__()
 
         # Build modules for CapsNet.
@@ -31,7 +31,7 @@ class CapsuleNetwork(nn.Module):
         )
 
         ## PrimaryCaps layer
-        self.primary_caps = PrimaryCaps(256, 32, 8, is_relu=is_relu)
+        self.primary_caps = PrimaryCaps(256, 32, 8)
 
         ## DigitCaps layer
         self.digit_caps = DigitCaps(1152, 8, 10, 16, routing_iters=routing_iters)


### PR DESCRIPTION
Remove ReLU activation in PrimaryCaps because it does not improve accuracy.